### PR TITLE
Resolved UnityEditor Build Errors

### DIFF
--- a/Assets/Scripts/AnimationWindowUtils.cs
+++ b/Assets/Scripts/AnimationWindowUtils.cs
@@ -22,16 +22,21 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 
 public static class AnimationWindowUtils {
-    public static Assembly GetUnityEditorAssembly() {
-        return typeof(AnimationUtility).Assembly;
-    }
+    #if UNITY_EDITOR
+		public static Assembly GetUnityEditorAssembly ()
+		{
+				return typeof(AnimationUtility).Assembly;
+		}
+    
 
     public static object GetAnimationWindow() {
         Type animationWindow = GetUnityEditorAssembly().GetType("UnityEditor.AnimationWindow");
@@ -65,4 +70,5 @@ public static class AnimationWindowUtils {
     public static string GetPath(this GameObject gameObject) {
         return gameObject.transform.GetPath();
     }
+	#endif
 }

--- a/Assets/Scripts/Bone.cs
+++ b/Assets/Scripts/Bone.cs
@@ -23,7 +23,9 @@ THE SOFTWARE.
 */
 
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.Collections;
 using System.Linq;
 using System.Linq.Expressions;
@@ -48,6 +50,7 @@ public class Bone : MonoBehaviour {
         }
     }
 
+    #if UNITY_EDITOR
     [MenuItem("GameObject/Create Other/Bone")]
     public static Bone Create() {
         GameObject b = new GameObject("Bone");
@@ -124,7 +127,7 @@ public class Bone : MonoBehaviour {
     public void AddIK() {
         Undo.AddComponent<InverseKinematics>(gameObject);
     }
-
+    #endif
     // Use this for initialization
 	void Start () {
         if (gameObject.transform.parent != null)
@@ -140,6 +143,7 @@ public class Bone : MonoBehaviour {
         }
 	}
 
+    #if UNITY_EDITOR
     void OnDrawGizmos() {
         if (gameObject.Equals(Selection.activeGameObject)) {
             Gizmos.color = Color.yellow;
@@ -172,6 +176,7 @@ public class Bone : MonoBehaviour {
             Gizmos.DrawWireSphere(Head, influenceHead);
         }
     }
+    #endif
 
     public float GetInfluence(Vector2 p) {
         Vector2 wv = Head - (Vector2)transform.position;

--- a/Assets/Scripts/Helper.cs
+++ b/Assets/Scripts/Helper.cs
@@ -23,42 +23,47 @@ THE SOFTWARE.
 */
 
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.Collections;
 
 public class Helper : MonoBehaviour {
     public HelperType type = HelperType.WireCube;
 
-    [MenuItem("GameObject/Create Other/Helper")]
-    public static void Create() {
-        GameObject o = new GameObject("Helper");
-        Undo.RegisterCreatedObjectUndo(o, "Create helper");
-        o.AddComponent<Helper>();
-    }
+    #if UNITY_EDITOR
+		[MenuItem("GameObject/Create Other/Helper")]
+		public static void Create ()
+		{
+				GameObject o = new GameObject ("Helper");
+				Undo.RegisterCreatedObjectUndo (o, "Create helper");
+				o.AddComponent<Helper> ();
+		}
 
-    void OnDrawGizmos() {
-        if (gameObject.Equals(Selection.activeGameObject)) {
-            Gizmos.color = Color.yellow;
-        }
-        else {
-            Gizmos.color = Color.green;
-        }
+		void OnDrawGizmos ()
+		{
+				if (gameObject.Equals (Selection.activeGameObject)) {
+						Gizmos.color = Color.yellow;
+				} else {
+						Gizmos.color = Color.green;
+				}
 
-        switch (type) {
-            case HelperType.Cube:
-                Gizmos.DrawCube(transform.position, transform.localScale);
-                break;
-            case HelperType.Sphere:
-                Gizmos.DrawSphere(transform.position, transform.localScale.x);
-                break;
-            case HelperType.WireCube:
-                Gizmos.DrawWireCube(transform.position, transform.localScale);
-                break;
-            case HelperType.WireSphere:
-                Gizmos.DrawWireSphere(transform.position, transform.localScale.x);
-                break;
-        }
-    }
+				switch (type) {
+				case HelperType.Cube:
+						Gizmos.DrawCube (transform.position, transform.localScale);
+						break;
+				case HelperType.Sphere:
+						Gizmos.DrawSphere (transform.position, transform.localScale.x);
+						break;
+				case HelperType.WireCube:
+						Gizmos.DrawWireCube (transform.position, transform.localScale);
+						break;
+				case HelperType.WireSphere:
+						Gizmos.DrawWireSphere (transform.position, transform.localScale.x);
+						break;
+				}
+		}
+    #endif
 }
 
 public enum HelperType {

--- a/Assets/Scripts/InverseKinematics.cs
+++ b/Assets/Scripts/InverseKinematics.cs
@@ -23,7 +23,9 @@ THE SOFTWARE.
 */
 
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System;
 using System.Collections.Generic;
 using System.Threading;

--- a/Assets/Scripts/ScriptableObjectUtility.cs
+++ b/Assets/Scripts/ScriptableObjectUtility.cs
@@ -22,28 +22,32 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.IO;
 
 public static class ScriptableObjectUtility {
     /// <summary>
     //	This makes it easy to create, name and place unique new ScriptableObject asset files.
     /// </summary>
-    public static void CreateAsset(Object asset) {
-        string path = AssetDatabase.GetAssetPath(Selection.activeObject);
-        if (path == "") {
-            path = "Assets";
-        }
-        else if (Path.GetExtension(path) != "") {
-            path = path.Replace(Path.GetFileName(AssetDatabase.GetAssetPath(Selection.activeObject)), "");
-        }
+   #if UNITY_EDITOR
+		public static void CreateAsset (Object asset)
+		{
+				string path = AssetDatabase.GetAssetPath (Selection.activeObject);
+				if (path == "") {
+						path = "Assets";
+				} else if (Path.GetExtension (path) != "") {
+						path = path.Replace (Path.GetFileName (AssetDatabase.GetAssetPath (Selection.activeObject)), "");
+				}
 
-        string assetPathAndName = AssetDatabase.GenerateUniqueAssetPath(path + "/New " + asset.GetType().ToString() + ".asset");
+				string assetPathAndName = AssetDatabase.GenerateUniqueAssetPath (path + "/New " + asset.GetType ().ToString () + ".asset");
 
-        AssetDatabase.CreateAsset(asset, assetPathAndName);
+				AssetDatabase.CreateAsset (asset, assetPathAndName);
 
-        AssetDatabase.SaveAssets();
+				AssetDatabase.SaveAssets ();
 
-        Selection.activeObject = asset;
-    }
+				Selection.activeObject = asset;
+		}
+   #endif
 }

--- a/Assets/Scripts/Skeleton.cs
+++ b/Assets/Scripts/Skeleton.cs
@@ -23,7 +23,9 @@ THE SOFTWARE.
 */
 
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
@@ -38,38 +40,42 @@ public class Skeleton : MonoBehaviour {
 
     private Pose tempPose;
 
-    [MenuItem("GameObject/Create Other/Skeleton")]
-    public static void Create() {
-        Undo.IncrementCurrentGroup();
+    #if UNITY_EDITOR
+		[MenuItem("GameObject/Create Other/Skeleton")]
+		public static void Create ()
+		{
+				Undo.IncrementCurrentGroup ();
 
-        GameObject o = new GameObject("Skeleton");
-        Undo.RegisterCreatedObjectUndo(o, "Create skeleton");
-        o.AddComponent<Skeleton>();
+				GameObject o = new GameObject ("Skeleton");
+				Undo.RegisterCreatedObjectUndo (o, "Create skeleton");
+				o.AddComponent<Skeleton> ();
 
-        GameObject b = new GameObject("Bone");
-        Undo.RegisterCreatedObjectUndo(b, "Create Skeleton");
-        b.AddComponent<Bone>();
+				GameObject b = new GameObject ("Bone");
+				Undo.RegisterCreatedObjectUndo (b, "Create Skeleton");
+				b.AddComponent<Bone> ();
 
-        b.transform.parent = o.transform;
+				b.transform.parent = o.transform;
 
-        Undo.CollapseUndoOperations(Undo.GetCurrentGroup());
-    }
+				Undo.CollapseUndoOperations (Undo.GetCurrentGroup ());
+		}
 
 	// Use this for initialization
 	void Start () {
         if (Application.isPlaying) {
+
             SetEditMode(false);
+
         }
 	}
 
     void OnEnable() {
-        EditorApplication.update += EditorUpdate;
+			EditorApplication.update += EditorUpdate;
     }
 
     void OnDisable() {
-        EditorApplication.update -= EditorUpdate;
+			EditorApplication.update -= EditorUpdate;
     }
-
+	#endif
     private void EditorUpdate() {
         foreach (Bone b in gameObject.GetComponentsInChildren<Bone>()) {
             InverseKinematics ik = b.GetComponent<InverseKinematics>();
@@ -82,6 +88,7 @@ public class Skeleton : MonoBehaviour {
 	
 	// Update is called once per frame
 	void Update () {
+		EditorUpdate();
         if (Application.isEditor) {
             foreach (Bone b in gameObject.GetComponentsInChildren<Bone>()) {
                 b.editMode = editMode;
@@ -118,7 +125,7 @@ public class Skeleton : MonoBehaviour {
 
         return pose;
     }
-
+#if UNITY_EDITOR
     public void SavePose() {
         ScriptableObjectUtility.CreateAsset(CreatePose());
     }
@@ -170,4 +177,5 @@ public class Skeleton : MonoBehaviour {
 
         editMode = edit;
     }
+#endif
 }

--- a/Assets/Scripts/Skin2D.cs
+++ b/Assets/Scripts/Skin2D.cs
@@ -22,7 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.Collections;
 using System.Linq;
 
@@ -37,12 +39,15 @@ public class Skin2D : MonoBehaviour {
     private MeshFilter meshFilter;
     private GameObject lastSelected = null;
 
-    [MenuItem("GameObject/Create Other/Skin 2D")]
-    public static void Create() {
-        GameObject o = new GameObject("Skin2D");
-        Undo.RegisterCreatedObjectUndo(o, "Create Skin2D");
-        o.AddComponent<Skin2D>();
-    }
+    #if UNITY_EDITOR
+		[MenuItem("GameObject/Create Other/Skin 2D")]
+		public static void Create ()
+		{
+				GameObject o = new GameObject ("Skin2D");
+				Undo.RegisterCreatedObjectUndo (o, "Create Skin2D");
+				o.AddComponent<Skin2D> ();
+		}
+    #endif
     
 	// Use this for initialization
 	void Start() {
@@ -76,9 +81,9 @@ public class Skin2D : MonoBehaviour {
             return lineMaterial;
         }
     }
-
+	#if UNITY_EDITOR
     void OnDrawGizmos() {
-#if UNITY_EDITOR
+
         if (Application.isEditor && MeshFilter.sharedMesh != null) {
             CalculateVertexColors();
             GL.wireframe = true;
@@ -86,7 +91,7 @@ public class Skin2D : MonoBehaviour {
             Graphics.DrawMeshNow(MeshFilter.sharedMesh, transform.position, transform.rotation);
             GL.wireframe = false;
         }
-#endif
+
     }
 
     public void CalculateBoneWeights() {
@@ -189,4 +194,5 @@ public class Skin2D : MonoBehaviour {
 
         PrefabUtility.ReplacePrefab(gameObject, obj, ReplacePrefabOptions.ConnectToPrefab);
     }
+	#endif
 }

--- a/Assets/Scripts/SkinMaker.cs
+++ b/Assets/Scripts/SkinMaker.cs
@@ -22,7 +22,9 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 */
 using UnityEngine;
+#if UNITY_EDITOR
 using UnityEditor;
+#endif
 using System.Collections;
 using System.Collections.Generic;
 


### PR DESCRIPTION
There is a lot of editor specific code that was causing errors when you
build. All Editor specific code has been surrounded in #if UNITY_EDITOR
selectors to allow this to compile.
